### PR TITLE
Add example macOS LaunchAgent

### DIFF
--- a/example.plist
+++ b/example.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>us.forpeople.kion_auth</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>kion-auth</string> <!-- Set this to the full path where kion-auth is -->
+        <string>--config</string>
+        <string>/Volumes/Shared_Files/config_share/kion-auth.ini</string> <!-- Set this to the full path where your config file is -->
+    </array>
+    <key>RunAtLoad</key> <!-- Run this when the service is first loaded -->
+    <true/>
+    <key>StartInterval</key>
+    <integer>12600</integer> <!-- Also run this every 3.5 hours (in seconds) -->
+</dict>
+</plist>


### PR DESCRIPTION
## What is this and why are we doing it?

Adds an example LaunchAgent configuration plist for macOS users.

Fixes #7 

## Are there any known security implications from this change?

No

## How did I test this?

Made my own LaunchAgent based on the example plist and enabled it. It ran.

## Should there be new or updated documentation for this change?

Need to add a wiki page for configuring this to run automatically. I will do this shortly.

## PR Checklist
- [x] I have linked this to the related issue (if applicable)
- [x] I have performed a self-review of my own code
- [x] I have commented my code (particularly the tricky bits)
- [x] I have made (or will make) changes to the documentation
