### PR TITLE
Fix release workflow by not using skipped builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GHA_CLI_PAT }}
         run: |
-          shaRunId="$(gh api /repos/hmrd-forpeople/kion-auth/actions/workflows/build.yml/runs --method get -f head_sha=${{ github.sha }} --jq ".workflow_runs[0].id")"
+          shaRunId="$(gh api /repos/hmrd-forpeople/kion-auth/actions/workflows/build.yml/runs --method get -f status=success -f head_sha=${{ github.sha }} --jq ".workflow_runs[0].id")"
           echo 'SHA_RUN_ID='$shaRunId >> $GITHUB_ENV
       - name: Download built binaries
         uses: actions/download-artifact@v5


### PR DESCRIPTION
## What is this and why are we doing it?

Release workflow broke -- github's api changed what it returns, apparently

## Are there any known security implications from this change?

None

## How did I test this?

yolo

## Should there be new or updated documentation for this change?

Nope

## PR Checklist
- [ ] I have linked this to the related issue (if applicable)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code (particularly the tricky bits)
- [ ] I have made (or will make) changes to the documentation
